### PR TITLE
refactor: allow use of typed loader/action functions

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,7 +1,7 @@
 import type {
   MetaFunction,
   LinksFunction,
-  LoaderFunction,
+  LoaderArgs,
 } from '@remix-run/cloudflare';
 import { useLoaderData } from '@remix-run/react';
 
@@ -16,14 +16,14 @@ export let links: LinksFunction = () => {
   return [];
 };
 
-export let loader: LoaderFunction = async ({ request }) => {
+export let loader = async ({ request }: LoaderArgs) => {
   return {
     title: 'remix-worker-template',
   };
 };
 
 export default function Index() {
-  let { title } = useLoaderData();
+  let { title } = useLoaderData<typeof loader>();
 
   return (
     <div>

--- a/worker.env.d.ts
+++ b/worker.env.d.ts
@@ -18,4 +18,6 @@ declare module '@remix-run/server-runtime' {
     env: Env;
     ctx: ExecutionContext;
   }
+
+  export * from '@remix-run/server-runtime/dist/index';
 }


### PR DESCRIPTION
First off, thanks for all the obvious hard work that has gone into this template! For anybody wanting to use new CloudFlare features like D1/Durable Objects with Remix, this is a game changer.

### The Problem

This has already been documented better elsewhere, but in short, being able to use type inference on the return types of loader/action functions makes our code significantly less brittle.

A prime example is in this template's index route:

```ts
export let loader: LoaderFunction = async ({ request }) => {
  return { title: 'remix-worker-template' }
};

export default function Index() {
  let { title } = useLoaderData()
  // ...
}
```

- In our render function, `title` has an `any` type, because `useLoaderData()` returns that by default.
- We can use `useLoaderData<typeof loader>()` to let it infer our loader's response data, but...
- ...`loader` is typed by `LoaderFunction`, which forces its return type to be `Promise<Response>`.

### The Solution

1. Instead of using `LoaderFunction` to specify the whole type of `loader`, we can choose to only specify a type for its arguments, using `LoaderArgs`. This means the return type of `loader` can be inferred by TypeScript based on the actual return value in code.
   
   > It would also be possible to use the `satisfies` keyword from TypeScript >=4.9:
   > ```ts
   > export let loader = async ({ request }) => { ... } satisfies LoaderFunction
   > ```
   
2. Unfortunately, due to the `declare module` in `worker.env.d.ts`, this removes the definition of `LoaderArgs`, which the `@remix-run/cloudflare` package re-exports directly from `@remix-run/server-runtime`. To work around this, we can have our overrides re-export `@remix-run/server-runtime` using its `./dist/index` path (such that TypeScript considers it as a separate module).

With these two tiny changes, you now get complete type inference of loader/action response types.

**Edit:** I just noticed this breaks the type override for `context` 🤦🏻 